### PR TITLE
chore: add pricing library docs

### DIFF
--- a/docs/pricing/6-order-export.mdx
+++ b/docs/pricing/6-order-export.mdx
@@ -1,6 +1,0 @@
----
-sidebar_position: 6
-title: Order Export
----
-
-TODO

--- a/docs/pricing/pricing-library/.nojekyll
+++ b/docs/pricing/pricing-library/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/pricing/pricing-library/README.md
+++ b/docs/pricing/pricing-library/README.md
@@ -1,0 +1,25 @@
+@epilot/pricing / [Exports](modules.md)
+
+# Pricing Library
+
+A library that provides pricing utility operations for Pricing Entities within the epilot 360 Platform, such as calculation of price item totals and aggregated totals. The purpose of this library is to provide support for common pricing concerns to all our APIs, micro-frontends and epilot Journeys.
+
+## Getting Started
+
+Install the package:
+
+```bash
+yarn add @epilot/pricing
+```
+
+```bash
+npm install --save @epilot/pricing
+```
+
+## Disclaimer
+
+This library is made available as an open source contribution to the community to ensure that all our clients and integrators can have the flexibility to build their own custom frontends and integrations with our platform [^1].
+
+However, this library is not intended to be used as a standalone product and it is not supported by epilot as such. If you have any questions or need help with this library, please contact your team.
+
+[^1]: With love & dedication by :heart: **tauro**.

--- a/docs/pricing/pricing-library/_category_.json
+++ b/docs/pricing/pricing-library/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Pricing Library", "position": 0 }

--- a/docs/pricing/pricing-library/enums/OperationType.md
+++ b/docs/pricing/pricing-library/enums/OperationType.md
@@ -1,0 +1,30 @@
+[@epilot/pricing](../README.md) / [Exports](../modules.md) / OperationType
+
+# Enumeration: OperationType
+
+## Table of contents
+
+### Enumeration Members
+
+- [DIVIDE](OperationType.md#divide)
+- [MULTIPLY](OperationType.md#multiply)
+
+## Enumeration Members
+
+### DIVIDE
+
+• **DIVIDE** = ``"divide"``
+
+#### Defined in
+
+[src/normalizers/constants.ts:5](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/normalizers/constants.ts#L5)
+
+___
+
+### MULTIPLY
+
+• **MULTIPLY** = ``"multiply"``
+
+#### Defined in
+
+[src/normalizers/constants.ts:4](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/normalizers/constants.ts#L4)

--- a/docs/pricing/pricing-library/enums/PricingModel.md
+++ b/docs/pricing/pricing-library/enums/PricingModel.md
@@ -1,0 +1,52 @@
+[@epilot/pricing](../README.md) / [Exports](../modules.md) / PricingModel
+
+# Enumeration: PricingModel
+
+## Table of contents
+
+### Enumeration Members
+
+- [perUnit](PricingModel.md#perunit)
+- [tieredFlatFee](PricingModel.md#tieredflatfee)
+- [tieredGraduated](PricingModel.md#tieredgraduated)
+- [tieredVolume](PricingModel.md#tieredvolume)
+
+## Enumeration Members
+
+### perUnit
+
+• **perUnit** = ``"per_unit"``
+
+#### Defined in
+
+[src/pricing.ts:37](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L37)
+
+___
+
+### tieredFlatFee
+
+• **tieredFlatFee** = ``"tiered_flatfee"``
+
+#### Defined in
+
+[src/pricing.ts:40](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L40)
+
+___
+
+### tieredGraduated
+
+• **tieredGraduated** = ``"tiered_graduated"``
+
+#### Defined in
+
+[src/pricing.ts:38](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L38)
+
+___
+
+### tieredVolume
+
+• **tieredVolume** = ``"tiered_volume"``
+
+#### Defined in
+
+[src/pricing.ts:39](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L39)

--- a/docs/pricing/pricing-library/interfaces/PricingEntitiesExtractResult.md
+++ b/docs/pricing/pricing-library/interfaces/PricingEntitiesExtractResult.md
@@ -1,0 +1,47 @@
+[@epilot/pricing](../README.md) / [Exports](../modules.md) / PricingEntitiesExtractResult
+
+# Interface: PricingEntitiesExtractResult
+
+## Table of contents
+
+### Properties
+
+- [\_tags](PricingEntitiesExtractResult.md#_tags)
+- [price](PricingEntitiesExtractResult.md#price)
+- [product](PricingEntitiesExtractResult.md#product)
+
+## Properties
+
+### \_tags
+
+• **\_tags**: `string`[]
+
+All pricing tags inferred from the products and prices of the provided price items.
+
+#### Defined in
+
+[src/pricing.ts:76](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L76)
+
+___
+
+### price
+
+• **price**: [`RelationAttributeValue`](../modules.md#relationattributevalue)
+
+A relation attribute value containing all price entities from the given price items.
+
+#### Defined in
+
+[src/pricing.ts:68](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L68)
+
+___
+
+### product
+
+• **product**: [`RelationAttributeValue`](../modules.md#relationattributevalue)
+
+A relation attribute value containing all product entities from the given price items.
+
+#### Defined in
+
+[src/pricing.ts:72](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L72)

--- a/docs/pricing/pricing-library/modules.md
+++ b/docs/pricing/pricing-library/modules.md
@@ -1,0 +1,839 @@
+[@epilot/pricing](README.md) / Exports
+
+# @epilot/pricing
+
+## Table of contents
+
+### Enumerations
+
+- [OperationType](enums/OperationType.md)
+- [PricingModel](enums/PricingModel.md)
+
+### Interfaces
+
+- [PricingEntitiesExtractResult](interfaces/PricingEntitiesExtractResult.md)
+
+### Type Aliases
+
+- [AmountFormatter](modules.md#amountformatter)
+- [ComputeAggregatedAndPriceTotals](modules.md#computeaggregatedandpricetotals)
+- [Currency](modules.md#currency)
+- [DineroConvertor](modules.md#dineroconvertor)
+- [PriceTierDisplayMode](modules.md#pricetierdisplaymode)
+- [PricingDetails](modules.md#pricingdetails)
+- [RelationAttributeValue](modules.md#relationattributevalue)
+- [Tax](modules.md#tax)
+- [TaxAmountBreakdown](modules.md#taxamountbreakdown)
+- [TimeFrequency](modules.md#timefrequency)
+- [TimeFrequencyNormalizerMatrix](modules.md#timefrequencynormalizermatrix)
+
+### Variables
+
+- [BillingPeriods](modules.md#billingperiods)
+- [DECIMAL\_PRECISION](modules.md#decimal_precision)
+- [DEFAULT\_CURRENCY](modules.md#default_currency)
+- [GENERIC\_UNIT\_DISPLAY\_LABEL](modules.md#generic_unit_display_label)
+- [TaxRates](modules.md#taxrates)
+- [timeFrequencyNormalizerMatrix](modules.md#timefrequencynormalizermatrix-1)
+
+### Functions
+
+- [computeAggregatedAndPriceTotals](modules.md#computeaggregatedandpricetotals-1)
+- [computePriceComponent](modules.md#computepricecomponent)
+- [computePriceItemDetails](modules.md#computepriceitemdetails)
+- [computeQuantities](modules.md#computequantities)
+- [extractPricingEntitiesBySlug](modules.md#extractpricingentitiesbyslug)
+- [formatAmount](modules.md#formatamount)
+- [formatAmountFromString](modules.md#formatamountfromstring)
+- [formatPriceUnit](modules.md#formatpriceunit)
+- [getDisplayTierByQuantity](modules.md#getdisplaytierbyquantity)
+- [getTierDescription](modules.md#gettierdescription)
+- [isPriceBuiltInUnit](modules.md#ispricebuiltinunit)
+- [isTaxInclusivePrice](modules.md#istaxinclusiveprice)
+- [normalizePriceMappingInput](modules.md#normalizepricemappinginput)
+- [normalizeTimeFrequency](modules.md#normalizetimefrequency)
+- [normalizeTimeFrequencyToDinero](modules.md#normalizetimefrequencytodinero)
+- [parseDecimalValue](modules.md#parsedecimalvalue)
+- [toDinero](modules.md#todinero)
+- [toDineroFromInteger](modules.md#todinerofrominteger)
+- [toIntegerAmount](modules.md#tointegeramount)
+
+## Type Aliases
+
+### AmountFormatter
+
+Ƭ **AmountFormatter**: (`{
+  amount,
+  currency,
+  format,
+  locale,
+}`: { `amount`: `number` \| `string` ; `currency?`: [`Currency`](modules.md#currency) ; `enableSubunitDisplay?`: `boolean` ; `format?`: `string` ; `locale?`: `string`  }) => `string`
+
+#### Type declaration
+
+▸ (`{
+  amount,
+  currency,
+  format,
+  locale,
+}`): `string`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `{
+  amount,
+  currency,
+  format,
+  locale,
+}` | `Object` |
+| `{
+  amount,
+  currency,
+  format,
+  locale,
+}.amount` | `number` \| `string` |
+| `{
+  amount,
+  currency,
+  format,
+  locale,
+}.currency?` | [`Currency`](modules.md#currency) |
+| `{
+  amount,
+  currency,
+  format,
+  locale,
+}.enableSubunitDisplay?` | `boolean` |
+| `{
+  amount,
+  currency,
+  format,
+  locale,
+}.format?` | `string` |
+| `{
+  amount,
+  currency,
+  format,
+  locale,
+}.locale?` | `string` |
+
+##### Returns
+
+`string`
+
+#### Defined in
+
+[src/formatters/index.ts:23](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L23)
+
+___
+
+### ComputeAggregatedAndPriceTotals
+
+Ƭ **ComputeAggregatedAndPriceTotals**: (`priceItems`: `PriceItemsDto`) => [`PricingDetails`](modules.md#pricingdetails)
+
+#### Type declaration
+
+▸ (`priceItems`): [`PricingDetails`](modules.md#pricingdetails)
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `priceItems` | `PriceItemsDto` |
+
+##### Returns
+
+[`PricingDetails`](modules.md#pricingdetails)
+
+#### Defined in
+
+[src/pricing.ts:43](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L43)
+
+___
+
+### Currency
+
+Ƭ **Currency**: ``"AED"`` \| ``"AFN"`` \| ``"ALL"`` \| ``"AMD"`` \| ``"ANG"`` \| ``"AOA"`` \| ``"ARS"`` \| ``"AUD"`` \| ``"AWG"`` \| ``"AZN"`` \| ``"BAM"`` \| ``"BBD"`` \| ``"BDT"`` \| ``"BGN"`` \| ``"BHD"`` \| ``"BIF"`` \| ``"BMD"`` \| ``"BND"`` \| ``"BOB"`` \| ``"BOV"`` \| ``"BRL"`` \| ``"BSD"`` \| ``"BTN"`` \| ``"BWP"`` \| ``"BYN"`` \| ``"BZD"`` \| ``"CAD"`` \| ``"CDF"`` \| ``"CHE"`` \| ``"CHF"`` \| ``"CHW"`` \| ``"CLF"`` \| ``"CLP"`` \| ``"CNY"`` \| ``"COP"`` \| ``"COU"`` \| ``"CRC"`` \| ``"CUC"`` \| ``"CUP"`` \| ``"CVE"`` \| ``"CZK"`` \| ``"DJF"`` \| ``"DKK"`` \| ``"DOP"`` \| ``"DZD"`` \| ``"EGP"`` \| ``"ERN"`` \| ``"ETB"`` \| ``"EUR"`` \| ``"FJD"`` \| ``"FKP"`` \| ``"GBP"`` \| ``"GEL"`` \| ``"GHS"`` \| ``"GIP"`` \| ``"GMD"`` \| ``"GNF"`` \| ``"GTQ"`` \| ``"GYD"`` \| ``"HKD"`` \| ``"HNL"`` \| ``"HRK"`` \| ``"HTG"`` \| ``"HUF"`` \| ``"IDR"`` \| ``"ILS"`` \| ``"INR"`` \| ``"IQD"`` \| ``"IRR"`` \| ``"ISK"`` \| ``"JMD"`` \| ``"JOD"`` \| ``"JPY"`` \| ``"KES"`` \| ``"KGS"`` \| ``"KHR"`` \| ``"KMF"`` \| ``"KPW"`` \| ``"KRW"`` \| ``"KWD"`` \| ``"KYD"`` \| ``"KZT"`` \| ``"LAK"`` \| ``"LBP"`` \| ``"LKR"`` \| ``"LRD"`` \| ``"LSL"`` \| ``"LYD"`` \| ``"MAD"`` \| ``"MDL"`` \| ``"MGA"`` \| ``"MKD"`` \| ``"MMK"`` \| ``"MNT"`` \| ``"MOP"`` \| ``"MRU"`` \| ``"MUR"`` \| ``"MVR"`` \| ``"MWK"`` \| ``"MXN"`` \| ``"MXV"`` \| ``"MYR"`` \| ``"MZN"`` \| ``"NAD"`` \| ``"NGN"`` \| ``"NIO"`` \| ``"NOK"`` \| ``"NPR"`` \| ``"NZD"`` \| ``"OMR"`` \| ``"PAB"`` \| ``"PEN"`` \| ``"PGK"`` \| ``"PHP"`` \| ``"PKR"`` \| ``"PLN"`` \| ``"PYG"`` \| ``"QAR"`` \| ``"RON"`` \| ``"RSD"`` \| ``"RUB"`` \| ``"RWF"`` \| ``"SAR"`` \| ``"SBD"`` \| ``"SCR"`` \| ``"SDG"`` \| ``"SEK"`` \| ``"SGD"`` \| ``"SHP"`` \| ``"SLL"`` \| ``"SOS"`` \| ``"SRD"`` \| ``"SSP"`` \| ``"STN"`` \| ``"SVC"`` \| ``"SYP"`` \| ``"SZL"`` \| ``"THB"`` \| ``"TJS"`` \| ``"TMT"`` \| ``"TND"`` \| ``"TOP"`` \| ``"TRY"`` \| ``"TTD"`` \| ``"TWD"`` \| ``"TZS"`` \| ``"UAH"`` \| ``"UGX"`` \| ``"USD"`` \| ``"USN"`` \| ``"UYI"`` \| ``"UYU"`` \| ``"UYW"`` \| ``"UZS"`` \| ``"VES"`` \| ``"VND"`` \| ``"VUV"`` \| ``"WST"`` \| ``"XAF"`` \| ``"XAG"`` \| ``"XAU"`` \| ``"XBA"`` \| ``"XBB"`` \| ``"XBC"`` \| ``"XBD"`` \| ``"XCD"`` \| ``"XDR"`` \| ``"XOF"`` \| ``"XPD"`` \| ``"XPF"`` \| ``"XPT"`` \| ``"XSU"`` \| ``"XTS"`` \| ``"XUA"`` \| ``"XXX"`` \| ``"YER"`` \| ``"ZAR"`` \| ``"ZMW"`` \| ``"ZWL"``
+
+ISO 4217 CURRENCY CODES as specified in the documentation
+Taken from https://www.iso.org/iso-4217-currency-codes.html
+sorted and parsed
+
+#### Defined in
+
+node_modules/@types/dinero.js/index.d.ts:96
+
+___
+
+### DineroConvertor
+
+Ƭ **DineroConvertor**: (`unitAmountDecimal`: `string`, `currency?`: [`Currency`](modules.md#currency)) => `dinero.Dinero`
+
+#### Type declaration
+
+▸ (`unitAmountDecimal`, `currency?`): `dinero.Dinero`
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `unitAmountDecimal` | `string` |
+| `currency?` | [`Currency`](modules.md#currency) |
+
+##### Returns
+
+`dinero.Dinero`
+
+#### Defined in
+
+[src/formatters/index.ts:53](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L53)
+
+___
+
+### PriceTierDisplayMode
+
+Ƭ **PriceTierDisplayMode**: `Components.Schemas.PriceTierDisplayMode`
+
+#### Defined in
+
+[src/types/index.d.ts:27](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/types/index.d.ts#L27)
+
+___
+
+### PricingDetails
+
+Ƭ **PricingDetails**: `Components.Schemas.PricingDetails`
+
+#### Defined in
+
+[src/types/index.d.ts:8](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/types/index.d.ts#L8)
+
+___
+
+### RelationAttributeValue
+
+Ƭ **RelationAttributeValue**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `$relation` | { `_schema`: `string` ; `_tags`: `string`[] ; `entity_id`: `string`  }[] |
+
+#### Defined in
+
+[src/pricing.ts:60](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L60)
+
+___
+
+### Tax
+
+Ƭ **Tax**: `Components.Schemas.Tax`
+
+#### Defined in
+
+[src/types/index.d.ts:11](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/types/index.d.ts#L11)
+
+___
+
+### TaxAmountBreakdown
+
+Ƭ **TaxAmountBreakdown**: `Components.Schemas.TaxAmountBreakdown`
+
+#### Defined in
+
+[src/types/index.d.ts:21](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/types/index.d.ts#L21)
+
+___
+
+### TimeFrequency
+
+Ƭ **TimeFrequency**: `Exclude`<`BillingPeriod`, ``"one_time"``\>
+
+#### Defined in
+
+[src/types/index.d.ts:25](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/types/index.d.ts#L25)
+
+___
+
+### TimeFrequencyNormalizerMatrix
+
+Ƭ **TimeFrequencyNormalizerMatrix**: { [outputFrequency in TimeFrequency]: { [inputFrequency in TimeFrequency]: Object } }
+
+A interface for a normalized time frequencies transformation matrix
+
+Eg. Output must be monthly, input was yearly
+
+`timeFrequencyNormalizerMatrix.yearly.monthly`
+
+#### Defined in
+
+[src/normalizers/constants.ts:15](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/normalizers/constants.ts#L15)
+
+## Variables
+
+### BillingPeriods
+
+• `Const` **BillingPeriods**: `Set`<`string`\>
+
+#### Defined in
+
+[src/pricing.ts:28](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L28)
+
+___
+
+### DECIMAL\_PRECISION
+
+• `Const` **DECIMAL\_PRECISION**: ``12``
+
+#### Defined in
+
+[src/formatters/constants.ts:1](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/constants.ts#L1)
+
+___
+
+### DEFAULT\_CURRENCY
+
+• `Const` **DEFAULT\_CURRENCY**: ``"EUR"``
+
+#### Defined in
+
+[src/currencies/index.ts:26](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/currencies/index.ts#L26)
+
+___
+
+### GENERIC\_UNIT\_DISPLAY\_LABEL
+
+• `Const` **GENERIC\_UNIT\_DISPLAY\_LABEL**: ``"unit"``
+
+#### Defined in
+
+[src/formatters/constants.ts:6](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/constants.ts#L6)
+
+___
+
+### TaxRates
+
+• `Const` **TaxRates**: `Readonly`<{ `nontaxable`: `number` = 0; `reduced`: `number` = 0.07; `standard`: `number` = 0.19 }\>
+
+#### Defined in
+
+[src/pricing.ts:30](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L30)
+
+___
+
+### timeFrequencyNormalizerMatrix
+
+• `Const` **timeFrequencyNormalizerMatrix**: [`TimeFrequencyNormalizerMatrix`](modules.md#timefrequencynormalizermatrix)
+
+A normalized time frequencies transformation matrix
+
+See also [TimeFrequencyNormalizerMatrix](modules.md#timefrequencynormalizermatrix)
+
+#### Defined in
+
+[src/normalizers/constants.ts:29](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/normalizers/constants.ts#L29)
+
+## Functions
+
+### computeAggregatedAndPriceTotals
+
+▸ **computeAggregatedAndPriceTotals**(`priceItems`): `PricingDetails`
+
+Computes all the integer amounts for the price items using the string decimal representation defined on prices unit_amount field.
+All totals are computed with a decimal precision of DECIMAL_PRECISION.
+After the calculations the integer amounts are scaled to a precision of 2.
+
+This compute function computes both line items and aggregated totals.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `priceItems` | `PriceItemsDto` |
+
+#### Returns
+
+`PricingDetails`
+
+#### Defined in
+
+[src/pricing.ts:43](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L43)
+
+___
+
+### computePriceComponent
+
+▸ **computePriceComponent**(`priceItemComponent`, `priceMappings`, `parentQuantity`): `PriceItem`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `priceItemComponent` | `PriceItemDto` |
+| `priceMappings` | `PriceInputMappings` |
+| `parentQuantity` | `number` |
+
+#### Returns
+
+`PriceItem`
+
+#### Defined in
+
+[src/pricing.ts:82](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L82)
+
+___
+
+### computePriceItemDetails
+
+▸ **computePriceItemDetails**(`priceItem`): `PricingDetails`
+
+Computes the pricing details for a given PriceItem in isolation.
+The computed price item will be the only entry from the PricingDetails items array.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `priceItem` | `PriceItemDto` \| `CompositePriceItemDto` | the price item to compute |
+
+#### Returns
+
+`PricingDetails`
+
+the pricing details
+
+#### Defined in
+
+[src/pricing.ts:313](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L313)
+
+___
+
+### computeQuantities
+
+▸ **computeQuantities**(`price`, `quantity?`, `priceMapping?`): `Object`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `price` | `Price` |
+| `quantity?` | `number` |
+| `priceMapping?` | `PriceInputMapping` |
+
+#### Returns
+
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `isUsingPriceMappingToSelectTier` | `boolean` |
+| `quantityToSelectTier` | `number` |
+| `safeQuantity` | `number` |
+| `unitAmountMultiplier` | `number` |
+
+#### Defined in
+
+[src/pricing.ts:645](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L645)
+
+___
+
+### extractPricingEntitiesBySlug
+
+▸ **extractPricingEntitiesBySlug**(`priceItems`): [`PricingEntitiesExtractResult`](interfaces/PricingEntitiesExtractResult.md)
+
+Extracts the pricing entities from a list of price items.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `priceItems` | (`PriceItem` \| `CompositePriceItem`)[] | a list of price items |
+
+#### Returns
+
+[`PricingEntitiesExtractResult`](interfaces/PricingEntitiesExtractResult.md)
+
+the product and price relations from the price items grouped by their slug.
+
+#### Defined in
+
+[src/pricing.ts:150](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/pricing.ts#L150)
+
+___
+
+### formatAmount
+
+▸ **formatAmount**(`«destructured»`): `string`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `«destructured»` | `Object` |
+| › `amount` | `string` \| `number` |
+| › `currency?` | [`Currency`](modules.md#currency) |
+| › `enableSubunitDisplay?` | `boolean` |
+| › `format?` | `string` |
+| › `locale?` | `string` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[src/formatters/index.ts:23](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L23)
+
+___
+
+### formatAmountFromString
+
+▸ **formatAmountFromString**(`«destructured»`): `string`
+
+Formats a decimal amount (string) to the desired user-displayable format
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `«destructured»` | `Object` |
+| › `currency?` | [`Currency`](modules.md#currency) |
+| › `decimalAmount` | `string` |
+| › `enableSubunitDisplay?` | `boolean` |
+| › `format?` | `string` |
+| › `locale?` | `string` |
+| › `precision?` | `number` |
+| › `useRealPrecision?` | `boolean` |
+
+#### Returns
+
+`string`
+
+- The user-displayable formatted amount
+
+#### Defined in
+
+[src/formatters/index.ts:36](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L36)
+
+___
+
+### formatPriceUnit
+
+▸ **formatPriceUnit**(`unit`, `hideGenericUnitLabel?`): `string`
+
+Formats built-in price units into a displayable representation. Eg. kw -> kW
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `unit` | `string` |
+| `hideGenericUnitLabel?` | `boolean` |
+
+#### Returns
+
+`string`
+
+the formatted unit
+
+#### Defined in
+
+[src/formatters/index.ts:54](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L54)
+
+___
+
+### getDisplayTierByQuantity
+
+▸ **getDisplayTierByQuantity**(`tiers`, `quantity`, `pricingModel`): `PriceTier`
+
+This function returns the price tier that matches the input quantity.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `tiers` | `PriceTier`[] | The price tiers. |
+| `quantity` | `number` | The quantity. |
+| `pricingModel` | ``"per_unit"`` \| ``"tiered_graduated"`` \| ``"tiered_volume"`` \| ``"tiered_flatfee"`` \| [`PricingModel`](enums/PricingModel.md) | The pricing model. |
+
+#### Returns
+
+`PriceTier`
+
+The selected tier.
+
+#### Defined in
+
+[src/tiers/index.ts:19](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/tiers/index.ts#L19)
+
+___
+
+### getTierDescription
+
+▸ **getTierDescription**(`pricingModel`, `tier`, `unit`, `locale`, `currency`, `t`, `options?`): `string`
+
+Get the tier description for a tiered price. This function will return a string
+describing the price, based on the tier and unit.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `pricingModel` | [`PricingModel`](enums/PricingModel.md) | - |
+| `tier` | `PriceTier` | The price tier. |
+| `unit` | `string` | The price unit. |
+| `locale` | `string` | The locale to use when formatting the price. |
+| `currency` | [`Currency`](modules.md#currency) | The currency to use when formatting |
+| `t` | (`key`: `string`, `options?`: { `defaultValue?`: `string` ; `ns`: `string`  }) => `string` | - |
+| `options` | `Object` | - |
+| `options.enableSubunitDisplay?` | `boolean` | - |
+| `options.showStartsAt?` | `boolean` | - |
+
+#### Returns
+
+`string`
+
+The tier description.
+
+#### Defined in
+
+[src/tiers/index.ts:49](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/tiers/index.ts#L49)
+
+___
+
+### isPriceBuiltInUnit
+
+▸ **isPriceBuiltInUnit**(`unit`): unit is string
+
+Checks whether a price unit is a built-in unit or not.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `unit` | `string` | the built-in unit code or user custom unit |
+
+#### Returns
+
+unit is string
+
+true if the unit is a built-in unit
+
+#### Defined in
+
+[src/formatters/index.ts:294](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L294)
+
+___
+
+### isTaxInclusivePrice
+
+▸ **isTaxInclusivePrice**(`price`): `boolean`
+
+Checks whether a price is tax inclusive or not.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `price` | `Price` | the price object |
+
+#### Returns
+
+`boolean`
+
+true if the price is tax inclusive, false otherwise. defaults to true.
+
+#### Defined in
+
+[src/utils/index.ts:39](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/utils/index.ts#L39)
+
+___
+
+### normalizePriceMappingInput
+
+▸ **normalizePriceMappingInput**(`priceMapping`, `price`): `Dinero`
+
+This function takes in a quantity, block mapping number, block mapping frequency, price, and parent quantity
+and returns the normalized quantity. The block mapping number and block mapping frequency are used to
+calculate the normalized quantity. The normalized quantity is the quantity multiplied by the block mapping
+number and block mapping frequency. The block mapping number and block mapping frequency are converted to
+dinero objects and then multiplied with the quantity. The normalized quantity is then multiplied by the
+parent quantity and returned.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `priceMapping` | `PriceInputMapping` | - |
+| `price` | `Price` | The price to be used to calculate the normalized quantity |
+
+#### Returns
+
+`Dinero`
+
+The normalized quantity
+
+#### Defined in
+
+[src/normalizers/index.ts:16](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/normalizers/index.ts#L16)
+
+___
+
+### normalizeTimeFrequency
+
+▸ **normalizeTimeFrequency**(`timeValue`, `timeValueFrequency`, `targetTimeFrequency`, `precision?`): `number`
+
+This function will normalize an inputted value of a specific time frequency to the
+desired time frequency based on constant values defined here [timeFrequencyNormalizerMatrix](modules.md#timefrequencynormalizermatrix-1).
+
+The default precision is set to 4 decimal places.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `timeValue` | `number` | the value in time that will be normalized |
+| `timeValueFrequency` | [`TimeFrequency`](modules.md#timefrequency) | the current time frequency of the value |
+| `targetTimeFrequency` | [`TimeFrequency`](modules.md#timefrequency) | the time frequency the value will be normalized to |
+| `precision?` | `number` | the precision of the normalized value |
+
+#### Returns
+
+`number`
+
+normalizedFrequencyInput
+
+See also [TimeFrequency](modules.md#timefrequency)
+
+#### Defined in
+
+[src/types/index.d.ts:28](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/types/index.d.ts#L28)
+
+___
+
+### normalizeTimeFrequencyToDinero
+
+▸ **normalizeTimeFrequencyToDinero**(`timeValue`, `timeValueFrequency`, `targetTimeFrequency`, `precision?`): `Dinero`
+
+This function will normalize an inputted value of a specific time frequency to the
+desired time frequency based on constant values defined here [timeFrequencyNormalizerMatrix](modules.md#timefrequencynormalizermatrix-1).
+
+The default dinerojs precision is set to 12 decimal places.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `timeValue` | `number` | the value in time that will be normalized |
+| `timeValueFrequency` | [`TimeFrequency`](modules.md#timefrequency) | the current time frequency of the value |
+| `targetTimeFrequency` | [`TimeFrequency`](modules.md#timefrequency) | the time frequency the value will be normalized to |
+| `precision?` | `number` | - |
+
+#### Returns
+
+`Dinero`
+
+a DineroJS object representing the normalized frequency input
+
+See also [TimeFrequency](modules.md#timefrequency)
+
+#### Defined in
+
+[src/types/index.d.ts:34](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/types/index.d.ts#L34)
+
+___
+
+### parseDecimalValue
+
+▸ **parseDecimalValue**(`value`): `string`
+
+Converts a decimal string value into a valid decimal amount value, without any thousand separators, using dot as the decimal separator.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `value` | `string` | The decimal string value to convert |
+
+#### Returns
+
+`string`
+
+A valid decimal amount value
+
+#### Defined in
+
+[src/formatters/index.ts:377](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L377)
+
+___
+
+### toDinero
+
+▸ **toDinero**(`unitAmountDecimal`, `currency?`): `Dinero`
+
+Convert an amount decimal and currency into a dinero object.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `unitAmountDecimal` | `string` |
+| `currency?` | [`Currency`](modules.md#currency) |
+
+#### Returns
+
+`Dinero`
+
+#### Defined in
+
+[src/formatters/index.ts:53](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L53)
+
+___
+
+### toDineroFromInteger
+
+▸ **toDineroFromInteger**(`integerAmount`, `currency?`): `Dinero`
+
+Utility mapper from Integer amount into DineroJS object using DECIMAL_PRECISION (12).
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `integerAmount` | `number` |
+| `currency?` | [`Currency`](modules.md#currency) |
+
+#### Returns
+
+`Dinero`
+
+#### Defined in
+
+[src/formatters/index.ts:268](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L268)
+
+___
+
+### toIntegerAmount
+
+▸ **toIntegerAmount**(`decimalAmount`): `number`
+
+Converts a string decimal amount to an integer amount with 2 digits precision.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `decimalAmount` | `string` | a string decimal amount |
+
+#### Returns
+
+`number`
+
+the decimal amount represent as an integer scaled to 2 decimal places precision.
+
+#### Defined in
+
+[src/formatters/index.ts:262](https://gitlab.com/e-pilot/product/checkout-and-pricing/pricing-api/-/blob/6ff898d/packages/pricing/src/formatters/index.ts#L262)


### PR DESCRIPTION
Adds our long-due Pricing Library docs for general epilot documentation, both for our engineers, our clients and integrators.

![Screenshot 2023-06-03 at 10 51 21](https://github.com/epilot-dev/docs/assets/4655079/0e7c1c9f-b33d-42b6-9ba5-bcb6d121df1e)
![Screenshot 2023-06-03 at 10 51 29](https://github.com/epilot-dev/docs/assets/4655079/0be60944-0106-4036-857d-e5e23da6b5f9)
![Screenshot 2023-06-03 at 10 51 41](https://github.com/epilot-dev/docs/assets/4655079/0f7a3a25-7a7c-4c11-ad9f-e145eed303b2)
