### PR TITLE
docs(journeys): link npm package and drop SDK beta notice

### DIFF
--- a/docs/journeys/sdk.md
+++ b/docs/journeys/sdk.md
@@ -9,12 +9,6 @@ The Journey Embed SDK is a chainable JavaScript API for rendering epilot Journey
 - A **rewritten iframe engine** that replaces the legacy [`__epilot` script](/docs/journeys/embedding) with a faster, cleaner host integration.
 - The [`<epilot-journey>` Web Component](/docs/journeys/web-components), a custom HTML element that renders in Shadow DOM.
 
-:::info Beta
-
-The SDK is in beta. Test it before rolling out to production. Existing embeds using the [legacy `__epilot` script](/docs/journeys/embedding) continue to work.
-
-:::
-
 :::tip When to use the SDK
 
 For iframe embedding, the SDK is the new default. It replaces the legacy `__epilot` script.
@@ -87,7 +81,7 @@ Before the bundle loads, `onReady(cb)` pushes `cb` onto a queue. When the bundle
 
 ### Option 3: npm package
 
-For bundler-based apps (Next.js, Vite, Webpack, etc.), install the SDK from npm. You'll get full TypeScript types and autocomplete:
+For bundler-based apps (Next.js, Vite, Webpack, etc.), install [`@epilot/journey-embed-sdk`](https://www.npmjs.com/package/@epilot/journey-embed-sdk) from npm. You'll get full TypeScript types and autocomplete:
 
 ```bash
 npm install @epilot/journey-embed-sdk


### PR DESCRIPTION
## Summary

Two small updates to the [Journey Embed SDK](docs/journeys/sdk.md) page:

- **Link the npm package.** In the *Option 3: npm package* install section, the `@epilot/journey-embed-sdk` package name now links to its [npm page](https://www.npmjs.com/package/@epilot/journey-embed-sdk).
- **Remove the beta notice.** The SDK is now generally available, so the `:::info Beta` admonition near the top of the page has been dropped.

## Test plan

- [ ] Docs preview renders the SDK page with the npm link resolving to https://www.npmjs.com/package/@epilot/journey-embed-sdk and no beta callout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2T8uLV7YeMnHHXc7DAaBd

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2T8uLV7YeMnHHXc7DAaBd)_