### PR TITLE
docs(journeys): document read-only block-type support

### DIFF
--- a/docs/journeys/embedding.md
+++ b/docs/journeys/embedding.md
@@ -60,7 +60,11 @@ export type DataInjectionOptions = {
   initialState?:
     | Record<string, Record<string, unknown>>
     | Record<string, unknown>[]
-  /** the display options to be passed to the journey, for now it is used to disable some fields */
+  /**
+   * the display options to be passed to the journey — used to render blocks (or
+   * specific fields) read-only. read-only is currently supported only for these
+   * block types: Personal Information, Address, Availability Check, and Text Input.
+   */
   blocksDisplaySettings?: BlockDisplaySetting[]
 }
 
@@ -103,6 +107,19 @@ __epilot.init([
 ```
 
 With the block-ID form you only list the blocks you actually want to prefill — there is no need to pad earlier steps with empty objects, and the mapping is unaffected by block renames or step reordering. To find a block's ID, open the block configurator in the Journey builder.
+
+### Making blocks read-only
+
+`blocksDisplaySettings` renders a block — or specific fields within it — as read-only: the prefilled values are shown but the end customer can't edit them. Each entry sets `type: 'DISABLED'` and targets a block by its stable `blockId` (recommended); add `blockFields` to lock only certain fields instead of the whole block.
+
+Read-only is currently supported only for these block types:
+
+- **Personal Information**
+- **Address**
+- **Availability Check**
+- **Text Input**
+
+Other block types don't support read-only.
 
 ### Data Injection builder (preview)
 

--- a/docs/journeys/sdk.md
+++ b/docs/journeys/sdk.md
@@ -510,7 +510,11 @@ type DataInjectionOptions = {
   initialState?:
     | Record<string, Record<string, unknown>>
     | Record<string, unknown>[]
-  /** Control which blocks/fields are disabled */
+  /**
+   * Control which blocks are disabled (rendered read-only). Read-only is
+   * currently supported only for these block types: Personal Information,
+   * Address, Availability Check, and Text Input.
+   */
   blocksDisplaySettings?: BlockDisplaySetting[]
 }
 
@@ -558,6 +562,19 @@ The same `.dataInjectionOptions({ ... })` call works with either backend — swa
 ### Populating `initialState`
 
 The recommended form keys `initialState` by **block ID**. Each entry is an object of the field values for that block. Because the state is keyed by block ID, you only list the blocks you actually want to prefill — no per-step ordering or empty `{}` placeholders are needed, and the mapping is unaffected by block renames or step reordering. To find a block's ID, open the block configurator in the Journey builder.
+
+### Making blocks read-only
+
+`blocksDisplaySettings` renders a block — or specific fields within it — as read-only: the prefilled values are shown but the end customer can't edit them. Each entry sets `type: 'DISABLED'` and targets a block by its stable `blockId` (recommended); add `blockFields` to lock only certain fields instead of the whole block.
+
+Read-only is currently supported only for these block types:
+
+- **Personal Information**
+- **Address**
+- **Availability Check**
+- **Text Input**
+
+Other block types don't support read-only.
 
 ### Data Injection Options builder
 

--- a/docs/journeys/web-components.md
+++ b/docs/journeys/web-components.md
@@ -193,7 +193,11 @@ type DataInjectionOptions = {
   initialState?:
     | Record<string, Record<string, unknown>>
     | Record<string, unknown>[]
-  /** Control which blocks/fields are disabled */
+  /**
+   * Control which blocks are disabled (rendered read-only). Read-only is
+   * currently supported only for these block types: Personal Information,
+   * Address, Availability Check, and Text Input.
+   */
   blocksDisplaySettings?: BlockDisplaySetting[]
 }
 
@@ -249,6 +253,19 @@ el.setAttribute(
 ### Populating `initialState`
 
 The recommended form keys `initialState` by **block ID**. Each entry is an object of the field values for that block. Because the state is keyed by block ID, you only list the blocks you actually want to prefill — no per-step ordering or empty `{}` placeholders are needed, and the mapping is unaffected by block renames or step reordering.
+
+### Making blocks read-only
+
+`blocksDisplaySettings` renders a block — or specific fields within it — as read-only: the prefilled values are shown but the end customer can't edit them. Each entry sets `type: 'DISABLED'` and targets a block by its stable `blockId` (recommended); add `blockFields` to lock only certain fields instead of the whole block.
+
+Read-only is currently supported only for these block types:
+
+- **Personal Information**
+- **Address**
+- **Availability Check**
+- **Text Input**
+
+Other block types don't support read-only.
 
 ### Data Injection builder (preview)
 


### PR DESCRIPTION
## Summary

Documents that read-only blocks (`blocksDisplaySettings` with `type: 'DISABLED'`) are **currently only supported for these block types**:

- Personal Information
- Address
- Availability Check
- Text Input

This wasn't mentioned anywhere before. Added in two places across all three embedding docs:

1. **In the `DataInjectionOptions` type** — expanded the `blocksDisplaySettings` doc comment to list the supported block types.
2. **A new "Making blocks read-only" section** — explains `blocksDisplaySettings` (`type: 'DISABLED'`, `blockId`, `blockFields`) and lists the supported block types.

## Files

- `docs/journeys/sdk.md`
- `docs/journeys/web-components.md`
- `docs/journeys/embedding.md` (legacy `__epilot`)

## Test plan

- [ ] Docs preview renders the new "Making blocks read-only" section and the updated type comment on all three pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2T8uLV7YeMnHHXc7DAaBd

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2T8uLV7YeMnHHXc7DAaBd)_