### PR TITLE
docs(files): document custom_download_url signature verification semantics

### DIFF
--- a/docs/files/file-api.md
+++ b/docs/files/file-api.md
@@ -216,6 +216,10 @@ POST /v2/files
 
 epilot retrieves external files on the fly with a short-lived signature and streams them directly to the end user. Use the [`verifyCustomDownloadUrl` operation](/api/file#tag/files/operation/verifyCustomDownloadUrl) to verify that a download request originates from epilot.
 
+:::info Signature verification details
+Pass the **full request URL exactly as received** to `verifyCustomDownloadUrl`. The signature covers a canonical form of the URL (query parameters sorted by key), so validity does not depend on the query parameter **order** — but every parameter and value must be present and unmodified. Signatures are cryptographically bound to the epilot organization and expire **15 minutes** after minting.
+:::
+
 ![External file download flow](../../static/img/file-custom-url-flow.png)
 
 :::warning


### PR DESCRIPTION
Documents how `verifyCustomDownloadUrl` treats the request URL, following the file-api change that canonicalizes the signed message (query params sorted by key):

- Pass the full request URL **exactly as received** — verification is independent of query parameter **order**.
- All parameters and values must be present and unmodified.
- Signatures are org-bound and expire **15 minutes** after minting.

Context: the previous byte-exact verification deterministically failed for consumers behind API Gateway REST (payload v1), which alphabetizes query params — e.g. the erp-integration file proxy streaming endpoint. Companion changes:
- file-api: https://gitlab.com/e-pilot/product/file-management/file-api/-/merge_requests/269
- erp-integration-api: https://gitlab.com/e-pilot/product/external-integrations/erp-integration-api/-/merge_requests/134

🤖 Generated with [Claude Code](https://claude.com/claude-code)